### PR TITLE
Fix a typo in the start message

### DIFF
--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -97,7 +97,7 @@ module Gcpc
         ack(message) if @ack_immediately
 
         begin
-          worker_info("Started hanlding message")
+          worker_info("Started handling message")
           @handler.handle(message)
           worker_info("Finished hanlding message successfully")
         rescue => e


### PR DESCRIPTION
## Why && What

This PR fixes a typo in the start message (`Started hanlding message` → `Started handling message`).
