### PR TITLE
Implement worker heartbeat logic

### DIFF
--- a/lib/gcpc.rb
+++ b/lib/gcpc.rb
@@ -4,11 +4,4 @@ require "gcpc/subscriber"
 require "gcpc/config"
 
 module Gcpc
-  def self.default_config
-      @config ||= Gcpc::Config.new
-  end
-
-  def self.configure
-    yield default_config
-  end
 end

--- a/lib/gcpc.rb
+++ b/lib/gcpc.rb
@@ -1,6 +1,14 @@
 require "gcpc/version"
 require "gcpc/publisher"
 require "gcpc/subscriber"
+require "gcpc/config"
 
 module Gcpc
+  def self.default_config
+      @config ||= Gcpc::Config.new
+  end
+
+  def self.configure
+    yield default_config
+  end
 end

--- a/lib/gcpc/config.rb
+++ b/lib/gcpc/config.rb
@@ -2,23 +2,21 @@ require "forwardable"
 
 module Gcpc
   class Config
-    extend Forwardable
+    class << self
+      attr_accessor :instance
+    end
 
-    LIFECYCLE_EVENTS = {
-      # triggers on every 10 seconds if process alive
-      beat: []
-    }
-
-    def_delegators :@lifecycle_events, :[]
+    attr_reader :beat
 
     def initialize
-      @lifecycle_events = LIFECYCLE_EVENTS
+      @beat = []
+      self.class.instance = self
     end
 
     def on(event, &block)
-      raise ArgumentError, "Invalid event name: #{event}" unless @lifecycle_events.keys.include?(event)
+      raise ArgumentError, "Invalid event name: #{event}" if event != :beat
 
-      @lifecycle_events[event] << block
+      @beat << block
     end
   end
 end

--- a/lib/gcpc/config.rb
+++ b/lib/gcpc/config.rb
@@ -4,23 +4,21 @@ module Gcpc
   class Config
     extend Forwardable
 
-    DEFAULTS = {
-      lifecycle_events: {
-        # triggers on every 10 seconds if process alive
-        beat: []
-      }
+    LIFECYCLE_EVENTS = {
+      # triggers on every 10 seconds if process alive
+      beat: []
     }
 
-    def_delegators :@options, :[]
+    def_delegators :@lifecycle_events, :[]
 
     def initialize
-      @options = DEFAULTS
+      @lifecycle_events = LIFECYCLE_EVENTS
     end
 
     def on(event, &block)
-      raise ArgumentError, "Invalid event name: #{event}" unless @options[:lifecycle_events].keys.include?(event)
+      raise ArgumentError, "Invalid event name: #{event}" unless @lifecycle_events.keys.include?(event)
 
-      @options[:lifecycle_events][event] << block
+      @lifecycle_events[event] << block
     end
   end
 end

--- a/lib/gcpc/config.rb
+++ b/lib/gcpc/config.rb
@@ -1,16 +1,12 @@
-require "forwardable"
+require "singleton"
 
 module Gcpc
   class Config
-    class << self
-      attr_accessor :instance
-    end
-
+    include Singleton
     attr_reader :beat
 
     def initialize
       @beat = []
-      self.class.instance = self
     end
 
     def on(event, &block)

--- a/lib/gcpc/config.rb
+++ b/lib/gcpc/config.rb
@@ -1,0 +1,26 @@
+require "forwardable"
+
+module Gcpc
+  class Config
+    extend Forwardable
+
+    DEFAULTS = {
+      lifecycle_events: {
+        # triggers on every 10 seconds if process alive
+        beat: []
+      }
+    }
+
+    def_delegators :@options, :[]
+
+    def initialize
+      @options = DEFAULTS
+    end
+
+    def on(event, &block)
+      raise ArgumentError, "Invalid event name: #{event}" unless @options[:lifecycle_events].keys.include?(event)
+
+      @options[:lifecycle_events][event] << block
+    end
+  end
+end

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -108,9 +108,10 @@ module Gcpc
         # ・When processing a message, write the thread_id and timestamp at the start time into @heartbeat_queue,
         #   and remove that information from @heartbeat_queue when the processing within that thread is finished.
         # ・If the processing of the message gets stuck, the timestamp will not be removed from @heartbeat_queue.
-        # ・Since the application holds as many streams as @subscriber.streams(int) with Subscription,
-        #   if the number of threads that have gotten stuck exceeds that stream, it is considered that the worker　unable to process Subscription queue.
-        return @heartbeat_queue.find_all{ |q| q[:start] < Time.now.to_i - WORKER_DEAD_THRESHOLD }.length >= @subscriber.streams
+        # ・Since the application holds as many callback_threads as @subscriber.callback_threads with Subscription,
+        #   if the number of threads that have gotten stuck exceeds that callback_threads, it is considered that the worker unable to process Subscription queue.
+        number_of_dead_threads = @heartbeat_queue.find_all{ |q| q[:start] < Time.now.to_i - WORKER_DEAD_THRESHOLD }.length 
+        return number_of_dead_threads >= @subscriber.callback_threads
       end
 
       def check_heartbeat

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -118,7 +118,8 @@ module Gcpc
         return unless @heartbeat
         Thread.new do
           loop do
-            return if worker_dead? || stopped?
+            break if stopped?
+            next if worker_dead?
 
             FileUtils.mkdir_p(File.dirname(@heartbeat_file_path)) unless File.exist?(@heartbeat_file_path)
             open(@heartbeat_file_path, 'w') do |f|

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -75,6 +75,7 @@ module Gcpc
 
         begin
           @heartbeat_worker_thread&.wakeup
+        # ThreadError exeption will be raised when the thread already dead
         rescue ThreadError => e
           @logger.error(e.message)
         end

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -201,7 +201,7 @@ module Gcpc
             end
           end
         rescue ThreadError => e
-          raise "Falied to update heartbeat_queue. thread_id: #{thread_id}, heartbeat_queue: #{@heartbeat_queue}, error: #{e.message}"
+          @logger.info("Falied to update heartbeat_queue. thread_id: #{thread_id}, heartbeat_queue: #{@heartbeat_queue}, error: #{e.message}")
         end
       end
     end

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -75,10 +75,11 @@ module Gcpc
 
         begin
           @heartbeat_worker_thread&.wakeup
-          @heartbeat_worker_thread&.join
         rescue ThreadError => e
           @logger.error(e.message)
         end
+
+        @heartbeat_worker_thread&.join
 
         @subscriber.wait!
 

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -25,7 +25,6 @@ module Gcpc
         @logger          = logger
         @subscriber_thread_status = {}
         @subscriber_thread_status_mutex = Mutex.new
-        @config          = Gcpc::Config.instance
         @heartbeat_worker_thread = nil
 
         @subscriber      = nil  # @subscriber is created by calling `#run`
@@ -113,7 +112,7 @@ module Gcpc
 
               next unless alive?
 
-              @config.beat.each(&:call)
+              Gcpc::Config.instance.beat.each(&:call)
 
               sleep BEAT_INTERVAL
             end

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -72,9 +72,14 @@ module Gcpc
         @logger.info('Stopping, will wait for background threads to exit')
 
         @subscriber.stop
-        # wakeup raise ThreadError when the thread dead
-        @heartbeat_worker_thread&.wakeup if @heartbeat_worker_thread&.alive?
-        @heartbeat_worker_thread&.join
+
+        begin
+          @heartbeat_worker_thread&.wakeup
+          @heartbeat_worker_thread&.join
+        rescue ThreadError => e
+          @logger.error(e.message)
+        end
+
         @subscriber.wait!
 
         @logger.info('Stopped, background threads are shutdown')

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -4,32 +4,26 @@ module Gcpc
   class Subscriber
     class Engine
       WAIT_INTERVAL = 1
-      DEFAULT_HEARTBEAT_FILE_PATH = "/var/tmp/gcpc_worker_heartbeat"
       WORKER_DEAD_THRESHOLD = 30 # second
+
 
       # @param [Google::Cloud::Pubsub::Subscription] subscription
       # @param [<#handle, #on_error>] interceptors
       # @param [bool] ack_immediately
       # @param [Logger] logger
-      # @param [bool] heartbeat
-      # @param [string] heartbeat_file_path
       def initialize(
         subscription:,
         interceptors:    [],
         ack_immediately: false,
-        logger:          DefaultLogger,
-        heartbeat: false,
-        heartbeat_file_path: DEFAULT_HEARTBEAT_FILE_PATH
+        logger:          DefaultLogger
       )
 
         @subscription    = subscription
         @interceptors    = interceptors
         @ack_immediately = ack_immediately
         @logger          = logger
-        @heartbeat       = heartbeat
-        @heartbeat_file_path = heartbeat_file_path
-        @heartbeat_queue = []
-        @heartbeat_queue_locker = Mutex.new
+        @subscriber_thread_status = {}
+        @subscriber_thread_status_mutex = Mutex.new
 
         @subscriber      = nil  # @subscriber is created by calling `#run`
         @handler         = nil  # @handler must be registered by `#handle`
@@ -56,8 +50,6 @@ module Gcpc
         @subscriber.start
 
         @logger.info("Started")
-
-        check_heartbeat
 
         loop_until_receiving_signals(signals)
       end
@@ -90,6 +82,21 @@ module Gcpc
         )
       end
 
+      def alive?
+        # ・When processing a message, write the thread_id and timestamp at the start time into @subscriber_thread_status,
+        #   and remove that information from @subscriber_thread_status when the processing within that thread is finished.
+        #   @subscriber_thread_status = {:thread_id_12140=>1689637971}
+        # ・If the processing of the message gets stuck, the key, value will not be removed from @subscriber_thread_status.
+        # ・Since the application holds as many callback_threads as @subscriber.callback_threads with Subscription,
+        #   if the number of threads that have gotten stuck exceeds that callback_threads, it is considered that the worker unable to process Subscription queue.
+        return false if !@subscriber
+        return false if !@subscriber.started?
+        return false if @subscriber.stopped?
+
+        number_of_dead_threads = @subscriber_thread_status.find_all { |_, v| v < Time.now.to_i - WORKER_DEAD_THRESHOLD }.length
+        return @subscriber.callback_threads > number_of_dead_threads
+      end
+
     private
 
       def loop_until_receiving_signals(signals)
@@ -104,36 +111,9 @@ module Gcpc
         stop unless stopped?
       end
 
-      def worker_dead?
-        # ・When processing a message, write the thread_id and timestamp at the start time into @heartbeat_queue,
-        #   and remove that information from @heartbeat_queue when the processing within that thread is finished.
-        # ・If the processing of the message gets stuck, the timestamp will not be removed from @heartbeat_queue.
-        # ・Since the application holds as many callback_threads as @subscriber.callback_threads with Subscription,
-        #   if the number of threads that have gotten stuck exceeds that callback_threads, it is considered that the worker unable to process Subscription queue.
-        number_of_dead_threads = @heartbeat_queue.find_all{ |q| q[:start] < Time.now.to_i - WORKER_DEAD_THRESHOLD }.length 
-        return number_of_dead_threads >= @subscriber.callback_threads
-      end
-
-      def check_heartbeat
-        return unless @heartbeat
-        Thread.new do
-          loop do
-            break if stopped?
-            next if worker_dead?
-
-            FileUtils.mkdir_p(File.dirname(@heartbeat_file_path)) unless File.exist?(@heartbeat_file_path)
-            open(@heartbeat_file_path, 'w') do |f|
-              f.puts(Time.now.to_i)
-            end
-
-            sleep 5
-          end
-        end
-      end
-
       # @param [Google::Cloud::Pubsub::ReceivedMessage] message
       def handle_message(message)
-        write_heartbeat_to_store('start')
+        write_heartbeat_to_subscriber_thread_status
 
         ack(message) if @ack_immediately
 
@@ -143,23 +123,21 @@ module Gcpc
           worker_info("Finished hanlding message successfully")
         rescue => e
           nack(message) if !@ack_immediately
-
-          write_heartbeat_to_store('end')
-
           raise e  # exception is handled in `#handle_error`
         end
 
         ack(message) if !@ack_immediately
-        write_heartbeat_to_store('end')
       end
 
       def ack(message)
         message.ack!
+        gc_subscriber_thread_status
         worker_info("Acked message")
       end
 
       def nack(message)
         message.nack!
+        gc_subscriber_thread_status
         worker_info("Nacked message")
       end
 
@@ -184,24 +162,29 @@ module Gcpc
       def stopped?
         @stopped_mutex.synchronize { @stopped }
       end
+      
+      def write_heartbeat_to_subscriber_thread_status
+        thread_id = Thread.current.object_id
 
-      def write_heartbeat_to_store(type)
         begin
-          @heartbeat_queue_locker.synchronize do
-            thread_id = Thread.current.object_id
-
-            case type
-            when 'start'
-              @heartbeat_queue.push({ thread_id: thread_id, start: Time.now.to_i })
-            when 'end'
-              # GC @heartbeat_queue to avoid memory leak
-              @heartbeat_queue.delete_if { |q| q[:thread_id] == thread_id }
-            else
-              raise "Invalid type passed to write_heartbeat_to_store: #{type}"
-            end
+          @subscriber_thread_status_mutex.synchronize do
+            @subscriber_thread_status["thread_id_#{thread_id.to_s.to_sym}".to_sym] = Time.now.to_i
           end
         rescue ThreadError => e
-          @logger.info("Falied to update heartbeat_queue. thread_id: #{thread_id}, heartbeat_queue: #{@heartbeat_queue}, error: #{e.message}")
+          @logger.info("Falied to write subscriber_thread_status. thread_id: #{thread_id}, subscriber_thread_status: #{@subscriber_thread_status}, error: #{e.message}")
+        end
+      end
+
+      def gc_subscriber_thread_status
+        thread_id = Thread.current.object_id
+
+        begin
+          @subscriber_thread_status_mutex.synchronize do
+            # GC to avoid memory leak
+            @subscriber_thread_status.delete_if { |k, _| k == "thread_id_#{thread_id.to_s.to_sym}".to_sym }
+          end
+        rescue ThreadError => e
+          @logger.info("Falied to gc subscriber_thread_status. thread_id: #{thread_id}, subscriber_thread_status: #{@subscriber_thread_status}, error: #{e.message}")
         end
       end
     end

--- a/lib/gcpc/subscriber/engine.rb
+++ b/lib/gcpc/subscriber/engine.rb
@@ -131,8 +131,7 @@ module Gcpc
         # ・If the processing of the message gets stuck, the key, value will not be removed from @subscriber_thread_status.
         # ・Since the application holds as many callback_threads as @subscriber.callback_threads with Subscription,
         #   if the number of threads that have gotten stuck exceeds that callback_threads, it is considered that the worker unable to process Subscription queue.
-        return false if !@subscriber
-        return false if !@subscriber.started?
+        return false unless @subscriber && @subscriber.started?
         return false if @subscriber.stopped?
 
         number_of_dead_threads = @subscriber_thread_status.count { |_, v| v < Time.now.to_i - WORKER_DEAD_THRESHOLD }

--- a/spec/gcpc/subscriber/engine_spec.rb
+++ b/spec/gcpc/subscriber/engine_spec.rb
@@ -109,7 +109,6 @@ describe Gcpc::Subscriber::Engine do
 
           # Don't do loop in #loop_until_receiving_signals
           expect(engine).to receive(:loop_until_receiving_signals).once
-          expect(engine.alive?).to eq false
 
           engine.run
 
@@ -120,11 +119,8 @@ describe Gcpc::Subscriber::Engine do
 
           expect(handler.handled.size).to eq 1
           expect(handler.handled.first).to eq "published payload"
-          expect(engine.alive?).to eq true
 
           engine.stop
-
-          expect(engine.alive?).to eq false
         end
       end
 

--- a/spec/gcpc/subscriber/engine_spec.rb
+++ b/spec/gcpc/subscriber/engine_spec.rb
@@ -1,18 +1,8 @@
 require "spec_helper"
 require "support/pubsub_resource_manager"
-require 'fileutils'
-require "tempfile"
 
 describe Gcpc::Subscriber::Engine do
   describe "#run and #stop" do
-    def heartbeat_value(file)
-      return nil if !File.exist?(file)
-
-      File.read(file).chomp.to_i
-    end
-
-    let(:temp_heartbeat_file_path) { Tempfile.open(['worker_heartbeat']) }
-
     context "when emulator is not running" do
       before do
         stub_const "FakeSubscription", Class.new
@@ -44,20 +34,16 @@ describe Gcpc::Subscriber::Engine do
             # Do nothing
           end
         end
-
-        FileUtils.rm(temp_heartbeat_file_path) if File.exist?(temp_heartbeat_file_path)
       end
 
       let(:engine) {
         Gcpc::Subscriber::Engine.new(
           subscription: FakeSubscription.new,
           logger:       Logger.new(nil),
-          heartbeat: true,
-          heartbeat_file_path: temp_heartbeat_file_path,
         )
       }
 
-      before do      
+      before do
         stub_const "NopHandler", Class.new(Gcpc::Subscriber::BaseHandler)
         engine.handle(NopHandler)
       end
@@ -67,7 +53,6 @@ describe Gcpc::Subscriber::Engine do
           .and_return(FakeSubscriber.new)
         expect_any_instance_of(FakeSubscriber).to receive(:on_error).once
         expect_any_instance_of(FakeSubscriber).to receive(:start).once
-        expect(engine).to receive(:check_heartbeat).once
         # Don't do loop in #loop_until_receiving_signals
         expect(engine).to receive(:loop_until_receiving_signals).once
 
@@ -114,19 +99,17 @@ describe Gcpc::Subscriber::Engine do
           end
         end
 
-        it "calls Google::Cloud::Pubsub::Subscription#start with heartbeat option" do
-          start_at = Time.now.to_i
+        it "calls Google::Cloud::Pubsub::Subscription#start" do
           subscription = pubsub_resource_manager.subscription
           engine = Gcpc::Subscriber::Engine.new(
-            subscription: subscription,
-            heartbeat: true,
-            heartbeat_file_path: temp_heartbeat_file_path
+            subscription: subscription
           )
           handler = Handler.new
           engine.handle(handler)
 
           # Don't do loop in #loop_until_receiving_signals
           expect(engine).to receive(:loop_until_receiving_signals).once
+          expect(engine.alive?).to eq false
 
           engine.run
 
@@ -137,34 +120,11 @@ describe Gcpc::Subscriber::Engine do
 
           expect(handler.handled.size).to eq 1
           expect(handler.handled.first).to eq "published payload"
-          expect(heartbeat_value(temp_heartbeat_file_path)).to be_between(start_at, Time.now.to_i)
+          expect(engine.alive?).to eq true
 
           engine.stop
-        end
 
-        it "calls Google::Cloud::Pubsub::Subscription#start without heartbeat option" do
-          subscription = pubsub_resource_manager.subscription
-          engine = Gcpc::Subscriber::Engine.new(
-            subscription: subscription,
-          )
-          handler = Handler.new
-          engine.handle(handler)
-
-          # Don't do loop in #loop_until_receiving_signals
-          expect(engine).to receive(:loop_until_receiving_signals).once
-
-          engine.run
-
-          topic = pubsub_resource_manager.topic
-          topic.publish("published payload")
-
-          sleep 1  # Wait until message is subscribed
-
-          expect(handler.handled.size).to eq 1
-          expect(handler.handled.first).to eq "published payload"
-          expect(heartbeat_value(Gcpc::Subscriber::Engine::DEFAULT_HEARTBEAT_FILE_PATH)).to eq nil
-
-          engine.stop
+          expect(engine.alive?).to eq false
         end
       end
 
@@ -178,13 +138,10 @@ describe Gcpc::Subscriber::Engine do
           end
         end
 
-        it "calls Subscriber::Engine#nack and Subscriber::Engine#handle_error with heartbeat option" do
-          start_at = Time.now.to_i
+        it "calls Subscriber::Engine#nack and Subscriber::Engine#handle_error" do
           subscription = pubsub_resource_manager.subscription
           engine = Gcpc::Subscriber::Engine.new(
-            subscription: subscription,
-            heartbeat: true,
-            heartbeat_file_path: temp_heartbeat_file_path
+            subscription: subscription
           )
           handler = Handler.new
           engine.handle(handler)
@@ -201,8 +158,6 @@ describe Gcpc::Subscriber::Engine do
           topic.publish("published payload")
 
           sleep 1  # Wait until message is subscribed
-
-          expect(heartbeat_value(temp_heartbeat_file_path)).to be_between(start_at, Time.now.to_i)
 
           engine.stop
         end

--- a/spec/support/pubsub_resource_manager.rb
+++ b/spec/support/pubsub_resource_manager.rb
@@ -40,5 +40,6 @@ class PubsubResourceManager
 
     @subscription = nil
     @topic        = nil
+    FileUtils.rm(Gcpc::Subscriber::Engine::DEFAULT_HEARTBEAT_FILE_PATH) if File.exist?(Gcpc::Subscriber::Engine::DEFAULT_HEARTBEAT_FILE_PATH)
   end
 end

--- a/spec/support/pubsub_resource_manager.rb
+++ b/spec/support/pubsub_resource_manager.rb
@@ -40,6 +40,5 @@ class PubsubResourceManager
 
     @subscription = nil
     @topic        = nil
-    FileUtils.rm(Gcpc::Subscriber::Engine::DEFAULT_HEARTBEAT_FILE_PATH) if File.exist?(Gcpc::Subscriber::Engine::DEFAULT_HEARTBEAT_FILE_PATH)
   end
 end


### PR DESCRIPTION
## Why
- Provide subscriber worker heartbeat to applications that use gcpc
- use case
  - check worker healthy/unhealthy via K8s health check like liveness, readiness etc.

## What
- provide beat lifecycle event
```
Gcpc::Config.instance.on(:beat) do
  p "Hi"
end
```

